### PR TITLE
Trying to fix the app

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -83,8 +83,8 @@ function update(){
     }
 }
 
-$testArrayAlpha=array('a','b','c','d','e','f','g','h','A','B','C','D','E','F','G','H');
-$testArrayNum=array(1,2,3,4,5,6,7,8);
+$testArrayAlpha=['a','b','c','d','e','f','g','h','A','B','C','D','E','F','G','H'];
+$testArrayNum=[1,2,3,4,5,6,7,8];
 $(document).ready(function(){
     const queryString = window.location.search;
     const urlParams = new URLSearchParams(queryString);

--- a/src/game.php
+++ b/src/game.php
@@ -25,7 +25,7 @@ class GameState extends ActiveRecord{
     }
 }
 
-$app = new \Slim\App();
+$app = new \Slim\App(['settings' => ['displayErrorDetails' => true]]);
 //$twig = new \Twig\Environment($loader, ['debug' => true]);
 $container = $app->getContainer();
 $container['view'] = function ($container) {
@@ -80,7 +80,7 @@ $app->get(
             echo "</br>"; 
         }
         */
-        return json_encode($Attributes);
+        return $response->withJson($Attributes);
     }
 );
 
@@ -93,18 +93,18 @@ $app->get('/board/{gameID}/{playerType}/{level}/{board}',
         $Game=$GameState->find($args['level']);
         if($args['playerType']=='A'){
             if($args['board']=='A'){
-                return json_encode($Game->data['playerABoard']);
+                return $response->withJson(json_decode($Game->data['playerABoard']));
             }
             else{
-                return json_encode($Game->data['playerAView']);
+                return $response->withJson(json_decode($Game->data['playerAView']));
             }
         }
         else{
             if($args['board']=='B'){
-                return json_encode($Game->data['playerBBoard']);
+                return $response->withJson(json_decode($Game->data['playerBBoard']));
             }
             else{
-                return json_encode($Game->data['playerBView']);
+                return $response->withJson(json_decode($Game->data['playerBView']));
             }
         }
     });
@@ -213,4 +213,3 @@ $app->get('/update/{gameID}',function($request, $response, array $args){
 });
 
 $app->run();
-?>


### PR DESCRIPTION
I think I found the problem you described me today.

Your endpoints were not returning JSON objects/arrays, but **strings** with json inside. This prevented the javascript from recognizing what the response really is.

i.e., you returned from the endpoint:

```
"[[0,0,1,0,0,0,1,0],[0,0,1,0,0,0,1,0],[0,0,1,0,0,0,1,0],[0,0,1,0,0,0,1,0],[0,0,1,1,1,1,0,0],[0,0,0,0,0,0,0,0],[1,1,1,0,0,1,0,0],[0,0,0,0,0,1,0,0]]"
```

but it should be (and is now):

```
[[0,0,1,0,0,0,1,0],[0,0,1,0,0,0,1,0],[0,0,1,0,0,0,1,0],[0,0,1,0,0,0,1,0],[0,0,1,1,1,1,0,0],[0,0,0,0,0,0,0,0],[1,1,1,0,0,1,0,0],[0,0,0,0,0,1,0,0]]
```

(notice: no quotes).

When you `return json_decode(...);` from the endpiont handler, Slim treats is as string, not JSON.

Finally, there is no `array(...)` notation in Javascript (game.js). I have changed the notation to JS, because it gave me errors immediately after starting the app (saw them in JS console - F12). 